### PR TITLE
Use uikit icon spinner when reindexing, better for dark themes

### DIFF
--- a/templates/reindex.thtml
+++ b/templates/reindex.thtml
@@ -85,7 +85,7 @@
 		<h3 class="uk-margin-bottom uk-margin-remove-top">{lang_ajax_status}</h3>
 
 		<div class="uk-margin">
-			<span id="t" class="tm-updating" style="display:none;">&nbsp;</span>
+                        <span id="t" style="display:none;"><i class="uk-icon uk-icon-refresh uk-icon-spin"></i></span>
 			<span class="msg" id="batchinterface_msg">&nbsp;</span>
 		</div>
 


### PR DESCRIPTION
I found that the spinning GIF image doesn't look so good on dark backgrounds, the UIkit icon seems to be much better.